### PR TITLE
update koupleless and sofa.ark versions from 1.4.2 snapshot to 1.4.2 …

### DIFF
--- a/dubbo-samples/rpc/dubbo26/pom.xml
+++ b/dubbo-samples/rpc/dubbo26/pom.xml
@@ -28,8 +28,8 @@
 		<dubbo.version>2.6.12</dubbo.version>
 		<dubbo.spring.boot.version>0.2.1.RELEASE</dubbo.spring.boot.version>
 		<spring.boot.version>2.7.16</spring.boot.version>
-		<koupleless.runtime.version>1.4.2-SNAPSHOT</koupleless.runtime.version>
-		<sofa.ark.version>2.2.16</sofa.ark.version>
+		<koupleless.runtime.version>1.4.2</koupleless.runtime.version>
+		<sofa.ark.version>2.3.1</sofa.ark.version>
 		<disruptor.version>3.4.2</disruptor.version>
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 	</properties>

--- a/dubbo-samples/rpc/dubbo27/pom.xml
+++ b/dubbo-samples/rpc/dubbo27/pom.xml
@@ -27,8 +27,8 @@
 		<maven.compiler.target>8</maven.compiler.target>
 		<dubbo.version>2.7.23</dubbo.version>
 		<spring.boot.version>2.7.16</spring.boot.version>
-		<koupleless.runtime.version>1.4.2-SNAPSHOT</koupleless.runtime.version>
-		<sofa.ark.version>2.2.16</sofa.ark.version>
+		<koupleless.runtime.version>1.4.2</koupleless.runtime.version>
+		<sofa.ark.version>2.3.1</sofa.ark.version>
 		<disruptor.version>3.4.2</disruptor.version>
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 	</properties>

--- a/dubbo-samples/rpc/dubbo3/pom.xml
+++ b/dubbo-samples/rpc/dubbo3/pom.xml
@@ -27,8 +27,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<spring.boot.version>2.7.16</spring.boot.version>
-		<koupleless.runtime.version>1.4.2-SNAPSHOT</koupleless.runtime.version>
-		<sofa.ark.version>2.2.16</sofa.ark.version>
+		<koupleless.runtime.version>1.4.2</koupleless.runtime.version>
+		<sofa.ark.version>2.3.1</sofa.ark.version>
 		<disruptor.version>3.4.2</disruptor.version>
 		<maven.compiler.plugin.version>3.8.1</maven.compiler.plugin.version>
 		<dubbo.version>3.1.11</dubbo.version>

--- a/feature-samples/pom.xml
+++ b/feature-samples/pom.xml
@@ -12,8 +12,8 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <koupleless.runtime.version>1.4.2-SNAPSHOT</koupleless.runtime.version>
-        <sofa.ark.version>2.2.16</sofa.ark.version>
+        <koupleless.runtime.version>1.4.2</koupleless.runtime.version>
+        <sofa.ark.version>2.3.1</sofa.ark.version>
         <disruptor.version>3.4.2</disruptor.version>
         <os.plugin.version>1.7.1</os.plugin.version>
         <protobuf.plugin.version>0.6.1</protobuf.plugin.version>

--- a/sofaboot-samples/pom.xml
+++ b/sofaboot-samples/pom.xml
@@ -21,8 +21,8 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <koupleless.runtime.version>1.4.2-SNAPSHOT</koupleless.runtime.version>
-        <sofa.ark.version>2.2.16</sofa.ark.version>
+        <koupleless.runtime.version>1.4.2</koupleless.runtime.version>
+        <sofa.ark.version>2.3.1</sofa.ark.version>
         <guice.version>6.0.0</guice.version>
         <guava.version>32.1.3-jre</guava.version>
         <curator.version>2.9.1</curator.version>

--- a/springboot-samples/pom.xml
+++ b/springboot-samples/pom.xml
@@ -14,8 +14,8 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <koupleless.runtime.version>1.4.2-SNAPSHOT</koupleless.runtime.version>
-        <sofa.ark.version>2.2.16</sofa.ark.version>
+        <koupleless.runtime.version>1.4.2</koupleless.runtime.version>
+        <sofa.ark.version>2.3.1</sofa.ark.version>
         <disruptor.version>3.4.2</disruptor.version>
         <os.plugin.version>1.7.1</os.plugin.version>
         <protobuf.plugin.version>0.6.1</protobuf.plugin.version>

--- a/springboot1-samples/pom.xml
+++ b/springboot1-samples/pom.xml
@@ -14,8 +14,8 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <koupleless.runtime.version>1.4.2-SNAPSHOT</koupleless.runtime.version>
-        <sofa.ark.version>2.2.16</sofa.ark.version>
+        <koupleless.runtime.version>1.4.2</koupleless.runtime.version>
+        <sofa.ark.version>2.3.1</sofa.ark.version>
         <disruptor.version>3.4.2</disruptor.version>
         <os.plugin.version>1.7.1</os.plugin.version>
         <protobuf.plugin.version>0.6.1</protobuf.plugin.version>


### PR DESCRIPTION
…and 2.3.1 respectively

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Koupleless runtime and Sofa Ark framework dependencies to their latest stable versions across multiple modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->